### PR TITLE
update to 1.9.6

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,2 @@
+del /F pyproject.toml
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,2 +1,2 @@
 rm -f pyproject.toml
-${PYTHON} -m pip install . --no-deps -vv
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - cartopy >=0.18.0
         - holoviews >=1.14.2
         - numpy
-        - param >=1.9.2
+        - param >=1.9.2,<2.0
         - scipy
     test:
       requires:
@@ -63,11 +63,6 @@ outputs:
         - wheel
       run:
         - python
-        - bokeh >=2.4.0,<2.5.0
-        - cartopy >=0.18.0
-        - holoviews >=1.14.2
-        - numpy
-        - param >=1.9.2,<2.0
         - {{ pin_subpackage('geoviews-core', exact=True) }}
         - datashader
         - geopandas-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ outputs:
     script: build_base.sh # [not win]
     script: build_base.bat # [win]
     build:
-      noarch: python
       entry_points:
         - geoviews = geoviews.__main__:main
     requirements:
@@ -36,10 +35,11 @@ outputs:
         - bokeh 2.4.3
         - nodejs 16.13.1
         - pyviz_comms 0.7.2
+        - cartopy 0.21.1
       run:
         - python
         - bokeh >=2.4.0,<2.5.0
-        - cartopy >=0.18.0
+        - cartopy >=0.21.1
         - holoviews >=1.14.2
         - numpy
         - param >=1.9.2,<2.0
@@ -53,8 +53,6 @@ outputs:
         - {{ name }}
 
   - name: {{ name }}
-    build:
-      noarch: python
     requirements:
       host:
         - python
@@ -71,6 +69,7 @@ outputs:
         - pyct
         - xarray
         - shapely
+        - scipy
         - pooch
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set name = "geoviews" %}
 
 package:
-  name: {{ name }}-core
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -30,19 +30,21 @@ outputs:
         - pip
         - setuptools
         - wheel
+        - packaging
         - param 1.9.0
         - pyct 0.5.0
         - bokeh 2.4.3
         - nodejs 16.13.1
         - cartopy 0.21.1
-        
+        - pyviz_comms 0.7.2
       run:
+        - python
         - bokeh >=2.4.0,<2.5.0
         - cartopy >=0.18.0
         - holoviews >=1.14.2
         - numpy >=1.0
         - param >=1.9.3
-        - packaging
+        - pykdtree
     test:
       requires:
         - pip
@@ -55,19 +57,28 @@ outputs:
     build:
       noarch: python
     requirements:
-      - python
-      - bokeh >=2.4.0,<2.5.0
-      - cartopy >=0.18.0
-      - holoviews >=1.14.2
-      - numpy >=1.0
-      - param >=1.9.3,<2.0
-      - {{ pin_subpackage('geoviews-core', exact=True) }}
-      - datashader
-      - geopandas-base
-      - netcdf4
-      - pandas
-      - pyct
-      - xarray
+      host:
+        - python
+        - pip
+        - setuptools
+        - wheel
+      run:
+        - python
+        - bokeh >=2.4.0,<2.5.0
+        - cartopy >=0.18.0
+        - holoviews >=1.14.2
+        - numpy >=1.0
+        - param >=1.9.3,<2.0
+        - {{ pin_subpackage('geoviews-core', exact=True) }}
+        - datashader
+        - geopandas-base
+        - netcdf4
+        - pandas
+        - pyct
+        - xarray
+        - shapely
+        - scipy
+        - pooch
     test:
       imports:
         - {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,6 @@ outputs:
         - pyct
         - xarray
         - shapely
-        - scipy
         - pooch
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ outputs:
         - holoviews >=1.14.2
         - numpy >=1.0
         - param >=1.9.3
-        - pykdtree
+        - scipy
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,91 +1,111 @@
-{% set version = "1.9.1" %}
+{% set version = "1.9.6" %}
+{% set name = "geoviews" %}
 
 package:
-  name: geoviews-core
+  name: {{ name }}-core
   version: {{ version }}
 
 source:
-  url: https://github.com/holoviz/geoviews/archive/v{{ version }}.tar.gz
-  sha256: 458bbe40b4bbf7bba5ef7b99d89a28618c024102545bc03687b6659368b335ed
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e2ab66626fb57434ede7670ed8b2b2e8331919dbec78edb4d1d1646dfa0c73e7
 
 build:
   number: 0
+  #skip s390x as lack of nodejs and cartopy dependencies
+  skip: True  # [py<37 or s390x]
 
 outputs:
-  - name: geoviews-core
-    script: build_base.sh
+  - name: {{ name }}-core
+    script: build_base.sh # [not win]
+    script: build_base.bat # [win]
     build:
       noarch: python
       entry_points:
         - geoviews = geoviews.__main__:main
     requirements:
       run_constrained:
-        - geoviews {{ version }}
+        - {{ name }} {{ version }}
       host:
-        - python >=3.6
+        - python
         - pip
-        - param >=1.9.0
-        # These are also needed at build time and declared in the pyproject.toml
-        - pyct >=0.4.4
-        - bokeh >=2.3.0,<2.4.0
-        - nodejs >=10.13.0
+        - setuptools
         - wheel
-        - cartopy >=0.18.0
-        - setuptools >=30.3.0
+        - param 1.9.0
+        - pyct 0.5.0
+        - bokeh 2.4.3
+        - nodejs 16.13.1
+        - cartopy 0.21.1
+        
       run:
-        - python >=3.6
-        - bokeh >=2.3.0,<2.4.0
+        - bokeh >=2.4.0,<2.5.0
         - cartopy >=0.18.0
         - holoviews >=1.14.2
-        - numpy  >=1.0
+        - numpy >=1.0
         - param >=1.9.3
+        - packaging
     test:
       requires:
         - pip
       commands:
         - pip check
       imports:
-        - geoviews
+        - {{ name }}
 
-  - name: geoviews
+  - name: {{ name }}
     build:
       noarch: python
     requirements:
-      - python >=3.6
-      - bokeh >=2.3.0,<2.4.0
+      - python
+      - bokeh >=2.4.0,<2.5.0
       - cartopy >=0.18.0
       - holoviews >=1.14.2
       - numpy >=1.0
       - param >=1.9.3,<2.0
-      - {{ pin_subpackage('geoviews-core', max_pin="x.x.x.x") }}
+      - {{ pin_subpackage('geoviews-core', exact=True) }}
       - datashader
-      - geopandas
+      - geopandas-base
       - netcdf4
       - pandas
       - pyct
       - xarray
     test:
       imports:
-        - geoviews
+        - {{ name }}
       requires:
         - nbsmoke
         - pytest
       commands:
         - geoviews examples --path=. --force
         # just run one notebook for now; increase in the future if notebooks can be run quickly with test/tiny data
-        - pytest --nbsmoke-run -k ".ipynb" user_guide/Geometries.ipynb
+        - pytest --nbsmoke-run -k ".ipynb" user_guide/Projections.ipynb
     about:
       home: https://geoviews.org
       license: BSD-3-Clause
+      license_family: BSD
       license_file: LICENSE
       summary: GeoViews is a Python library that makes it easy to explore and visualize geographical, meteorological, and oceanographic datasets, such as those used in weather, climate, and remote sensing research.
+      description: |
+        GeoViews is built on the HoloViews library for building flexible visualizations of multidimensional data. 
+        GeoViews adds a family of geographic plot types based on the Cartopy library, 
+        plotted using either the Matplotlib or Bokeh packages.
+      doc_url: https://geoviews.org
+      dev_url: https://github.com/holoviz/geoviews
 
 about:
   home: https://geoviews.org
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: GeoViews is a Python library that makes it easy to explore and visualize geographical, meteorological, and oceanographic datasets, such as those used in weather, climate, and remote sensing research.
+  description: |
+    GeoViews is built on the HoloViews library for building flexible visualizations of multidimensional data. 
+    GeoViews adds a family of geographic plot types based on the Cartopy library, 
+    plotted using either the Matplotlib or Bokeh packages.
+  doc_url: https://geoviews.org
+  dev_url: https://github.com/holoviz/geoviews
 extra:
   recipe-maintainers:
     - ocefpaf
     - philippjfr
+    - maximlt
+    - Hoxbro

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ outputs:
         - pyct 0.5.0
         - bokeh 2.4.3
         - nodejs 16.13.1
-        - cartopy 0.21.1
         - pyviz_comms 0.7.2
       run:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - cartopy >=0.18.0
         - holoviews >=1.14.2
         - numpy
-        - param >=1.9.3
+        - param >=1.9.2
         - scipy
     test:
       requires:
@@ -67,7 +67,7 @@ outputs:
         - cartopy >=0.18.0
         - holoviews >=1.14.2
         - numpy
-        - param >=1.9.3,<2.0
+        - param >=1.9.2,<2.0
         - {{ pin_subpackage('geoviews-core', exact=True) }}
         - datashader
         - geopandas-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ outputs:
         - bokeh >=2.4.0,<2.5.0
         - cartopy >=0.18.0
         - holoviews >=1.14.2
-        - numpy >=1.0
+        - numpy
         - param >=1.9.3
         - scipy
     test:
@@ -66,7 +66,7 @@ outputs:
         - bokeh >=2.4.0,<2.5.0
         - cartopy >=0.18.0
         - holoviews >=1.14.2
-        - numpy >=1.0
+        - numpy
         - param >=1.9.3,<2.0
         - {{ pin_subpackage('geoviews-core', exact=True) }}
         - datashader

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ outputs:
     script: build_base.sh # [not win]
     script: build_base.bat # [win]
     build:
+      noarch: python
       entry_points:
         - geoviews = geoviews.__main__:main
     requirements:
@@ -53,6 +54,7 @@ outputs:
 
   - name: {{ name }}
     build:
+      noarch: python
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ outputs:
     script: build_base.sh # [not win]
     script: build_base.bat # [win]
     build:
-      noarch: python
       entry_points:
         - geoviews = geoviews.__main__:main
     requirements:
@@ -54,7 +53,6 @@ outputs:
 
   - name: {{ name }}
     build:
-      noarch: python
     requirements:
       host:
         - python


### PR DESCRIPTION
update geoviews to 1.9.6

- support for python >=3.7 & <= 3.11
- strict pinning
- added packaging
- bokeh >= 2.4.0 & < 2.5.0
- added license_family, doc_url, dev_url, description