### PR TITLE
Update to 1.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,13 +30,13 @@ outputs:
         - setuptools
         - wheel
         - packaging
-        - param >=1.9.0,<3.0
+        - param =1.9
         - pyct 0.5.0
         - bokeh >=3.3.0,<3.4
         - nodejs 18.16
       run:
         - python
-        - bokeh >=3.2.0,<3.4.0
+        - bokeh =3.3
         - cartopy >=0.21.1
         - holoviews >=1.16.0
         - numpy >=1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,17 +30,17 @@ outputs:
         - setuptools
         - wheel
         - packaging
-        - param >=1.9.0
+        - param >=1.9.0,<3.0
         - pyct 0.5.0
         - bokeh =3.3
-        - nodejs 16.13.1
+        - nodejs 18.16
       run:
         - python
         - bokeh >=3.2.0,<3.4.0
         - cartopy >=0.21.1
         - holoviews >=1.16.0
         - numpy >=1.0
-        - param >=2.0.0,<3.0
+        - param >=1.9.0,<3.0
         - panel >=1.0.0
         - pyproj
         - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,12 +77,10 @@ outputs:
       requires:
         - nbval
         - pytest
-        - pip
       commands:
         - geoviews examples --path=. --force
         # just run one notebook for now; increase in the future if notebooks can be run quickly with test/tiny data
         - pytest --nbval-lax -k Projections.ipynb
-        - pip check
     about:
       home: https://geoviews.org
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ outputs:
         - panel >=1.0.0
         - pyproj
         - packaging
+        - shapely
+        - xyzservices
     test:
       requires:
         - pip
@@ -68,7 +70,6 @@ outputs:
         - pandas
         - pyct
         - xarray
-        - shapely
         - scipy
         - pooch
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,13 +76,8 @@ outputs:
       imports:
         - {{ name }}
       requires:
-        - nbval
-        - pytest
         - pip
       commands:
-        - geoviews examples --path=. --force
-        # just run one notebook for now; increase in the future if notebooks can be run quickly with test/tiny data
-        - pytest --nbval-lax -k Projections.ipynb
         - pip check
     about:
       home: https://geoviews.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,8 @@ outputs:
         - pyviz_comms >=0.6.0
       run:
         - python
-        - bokeh =3.3
-        - cartopy >=0.21.1
+        - bokeh >=3.2.0,<3.4
+        - cartopy >=0.18.0
         - holoviews >=1.16.0
         - numpy >=1.0
         - param >=1.9.0,<3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,12 @@ build:
   number: 0
   #skip s390x as lack of nodejs and cartopy dependencies
   skip: True  # [py<310 or s390x]
-
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
 outputs:
   - name: {{ name }}-core
     script: build_base.sh # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.6" %}
+{% set version = "1.11.1" %}
 {% set name = "geoviews" %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e2ab66626fb57434ede7670ed8b2b2e8331919dbec78edb4d1d1646dfa0c73e7
+  sha256: 6c65e2122c8b62ee7985bb956369d05953c7704081f90b686a0fdfaf20933d2b
 
 build:
   number: 0
   #skip s390x as lack of nodejs and cartopy dependencies
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<310 or s390x]
 
 outputs:
   - name: {{ name }}-core
@@ -30,20 +30,20 @@ outputs:
         - setuptools
         - wheel
         - packaging
-        - param 1.9.0
+        - param >=1.9.0
         - pyct 0.5.0
-        - bokeh 2.4.3
+        - bokeh =3.3
         - nodejs 16.13.1
-        - pyviz_comms 0.7.2
-        - cartopy 0.21.1
       run:
         - python
-        - bokeh >=2.4.0,<2.5.0
+        - bokeh >=3.2.0,<3.4.0
         - cartopy >=0.21.1
-        - holoviews >=1.14.2
-        - numpy
-        - param >=1.9.2,<2.0
-        - scipy
+        - holoviews >=1.16.0
+        - numpy >=1.0
+        - param >=2.0.0,<3.0
+        - panel >=1.0.0
+        - pyproj
+        - packaging
     test:
       requires:
         - pip
@@ -61,6 +61,14 @@ outputs:
         - wheel
       run:
         - python
+        - bokeh >=3.2.0,<3.4.0
+        - cartopy >=0.18.0
+        - holoviews >=1.16.0
+        - numpy  >=1.0
+        - param >=1.9.3
+        - panel >=1.0.0
+        - pyproj
+        - packaging
         - {{ pin_subpackage('geoviews-core', exact=True) }}
         - datashader
         - geopandas-base
@@ -68,19 +76,17 @@ outputs:
         - pandas
         - pyct
         - xarray
-        - shapely
-        - scipy
         - pooch
     test:
       imports:
         - {{ name }}
       requires:
-        - nbsmoke
+        - nbval
         - pytest
       commands:
         - geoviews examples --path=. --force
         # just run one notebook for now; increase in the future if notebooks can be run quickly with test/tiny data
-        - pytest --nbsmoke-run -k ".ipynb" user_guide/Projections.ipynb
+        - pytest --nbval-lax -k Projections.ipynb
     about:
       home: https://geoviews.org
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ outputs:
         - packaging
         - param >=1.9.0,<3.0
         - pyct 0.5.0
-        - bokeh =3.3
+        - bokeh >=3.3.0,<3.4
         - nodejs 18.16
       run:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,14 +61,6 @@ outputs:
         - wheel
       run:
         - python
-        - bokeh >=3.2.0,<3.4.0
-        - cartopy >=0.18.0
-        - holoviews >=1.16.0
-        - numpy  >=1.0
-        - param >=1.9.3
-        - panel >=1.0.0
-        - pyproj
-        - packaging
         - {{ pin_subpackage('geoviews-core', exact=True) }}
         - datashader
         - geopandas-base
@@ -76,6 +68,8 @@ outputs:
         - pandas
         - pyct
         - xarray
+        - shapely
+        - scipy
         - pooch
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,3 +114,5 @@ extra:
     - philippjfr
     - maximlt
     - Hoxbro
+  skip-lints:
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,10 +77,12 @@ outputs:
       requires:
         - nbval
         - pytest
+        - pip
       commands:
         - geoviews examples --path=. --force
         # just run one notebook for now; increase in the future if notebooks can be run quickly with test/tiny data
         - pytest --nbval-lax -k Projections.ipynb
+        - pip check
     about:
       home: https://geoviews.org
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   #skip s390x as lack of nodejs and cartopy dependencies
-  skip: True  # [py<310 or s390x]
+  skip: True  # [py<39 or s390x]
 requirements:
   host:
     - python
@@ -24,6 +24,7 @@ outputs:
     script: build_base.sh # [not win]
     script: build_base.bat # [win]
     build:
+      skip: True  # [py<39 or s390x]
       entry_points:
         - geoviews = geoviews.__main__:main
     requirements:
@@ -39,6 +40,7 @@ outputs:
         - pyct 0.5.0
         - bokeh >=3.3.0,<3.4
         - nodejs 18.16
+        - pyviz_comms >=0.6.0
       run:
         - python
         - bokeh =3.3
@@ -60,6 +62,8 @@ outputs:
         - {{ name }}
 
   - name: {{ name }}
+    build:
+      skip: True  # [py<39 or s390x]
     requirements:
       host:
         - python


### PR DESCRIPTION
geoviews 1.11.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/geoviews)
- [Upstream changelog/diff](https://github.com/holoviz/geoviews/compare/v1.9.6...v1.11.1#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)

### Explanation of changes:

- Last version on *defaults* is 1.9.6, we missed 1.10.0, 1.10.1, and 1.11.0.
- [conda-forge update for 1.11.1](https://github.com/conda-forge/geoviews-feedstock/pull/37/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a)
