### PR TITLE
Update to 1.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.11.1" %}
+{% set version = "1.12.0" %}
 {% set name = "geoviews" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6c65e2122c8b62ee7985bb956369d05953c7704081f90b686a0fdfaf20933d2b
+  sha256: e2cbef0605e8fd1529bc643a31aeb61997f8f93c9b41a5aff8b2b355a76fa789
 
 build:
   number: 0
@@ -36,14 +36,13 @@ outputs:
         - setuptools
         - wheel
         - packaging
-        - param =1.9
+        - param >=1.9.2
         - pyct 0.5.0
-        - bokeh >=3.3.0,<3.4
-        - nodejs 18.16
-        - pyviz_comms >=0.6.0
+        - bokeh ==3.4
+        - nodejs 20
       run:
         - python
-        - bokeh >=3.2.0,<3.4
+        - bokeh >=3.4.0,<3.5.0
         - cartopy >=0.18.0
         - holoviews >=1.16.0
         - numpy >=1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ outputs:
         - param >=1.9.2
         - pyct 0.5.0
         - bokeh ==3.4
-        - nodejs 20
+        - nodejs 18.16
       run:
         - python
         - bokeh >=3.4.0,<3.5.0


### PR DESCRIPTION
geoviews 1.12.0

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/geoviews)
- [Upstream changelog/diff](https://github.com/holoviz/geoviews/compare/v1.11.1...v1.12.0?short_path=60f61ab#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)

### Explanation of changes:

- https://github.com/conda-forge/geoviews-feedstock/pull/38/files
