### PR TITLE
v1.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.12.0" %}
+{% set version = "1.13.0" %}
 {% set name = "geoviews" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e2cbef0605e8fd1529bc643a31aeb61997f8f93c9b41a5aff8b2b355a76fa789
+  sha256: 7554a1e9114995acd243546fac6c6c7f157fc28529fde6ab236a72a6e77fe0bf
 
 build:
   number: 0
@@ -31,25 +31,25 @@ outputs:
       run_constrained:
         - {{ name }} {{ version }}
       host:
-        - python
+        - python >=3.10
         - pip
         - setuptools
         - wheel
         - packaging
-        - param >=1.9.2
-        - pyct 0.5.0
-        - bokeh ==3.4
-        - nodejs 18.16
+        - bokeh =3.5
+        - nodejs >=20
+        - hatchling
+        - hatch-vcs
       run:
-        - python
-        - bokeh >=3.4.0,<3.5.0
+        - python >=3.10
+        - bokeh >=3.5.0,<3.6.0
         - cartopy >=0.18.0
         - holoviews >=1.16.0
         - numpy >=1.0
-        - param >=1.9.0,<3.0
-        - panel >=1.0.0
-        - pyproj
         - packaging
+        - panel >=1.0.0
+        - param >=1.9.3
+        - pyproj
         - shapely
         - xyzservices
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ outputs:
         - numpy >=1.0
         - packaging
         - panel >=1.0.0
-        - param >=1.9.3
+        - param >=1.9.3,<3.0
         - pyproj
         - shapely
         - xyzservices


### PR DESCRIPTION
geoviews 1.13.0

Destination channel: defaults

Links
[Upstream repository](https://github.com/holoviz/geoviews)
[Upstream changelog/diff](https://github.com/holoviz/geoviews/compare/v1.12.0...v1.13.0)
Explanation of changes:
https://github.com/conda-forge/geoviews-feedstock/pull/41/files