### PR TITLE
Update to v1.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.13.0" %}
+{% set version = "1.13.1" %}
 {% set name = "geoviews" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7554a1e9114995acd243546fac6c6c7f157fc28529fde6ab236a72a6e77fe0bf
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d1cdb21bcde8ddf2a7f88df1506395a86f6e708bcf9289c5551d5a095200167f
 
 build:
   number: 0


### PR DESCRIPTION
geoviews 1.13.1

Destination channel: defaults

Links
[Upstream repository](https://github.com/holoviz/geoviews)
[Upstream changelog/diff](https://github.com/holoviz/geoviews/compare/v1.13.0...v1.13.1)