### PR TITLE
Update to v1.14.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.13.1" %}
+{% set version = "1.14.0" %}
 {% set name = "geoviews" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d1cdb21bcde8ddf2a7f88df1506395a86f6e708bcf9289c5551d5a095200167f
+  sha256: 3cca679a32b2c97215424a3a154e3fa343f61e2589d15e333e493bdf2f62fc6a
 
 build:
   number: 0
@@ -33,13 +33,13 @@ outputs:
       host:
         - python
         - pip
-        - bokeh >=3.5.0,<3.6.0
+        - bokeh >=3.6.0,<3.7.0
         - nodejs >=20
         - hatchling
         - hatch-vcs
       run:
         - python
-        - bokeh >=3.5.0,<3.6.0
+        - bokeh >=3.6.0
         - cartopy >=0.18.0
         - holoviews >=1.16.0
         - numpy >=1.0


### PR DESCRIPTION
geoviews 1.14.0

Destination channel: defaults

Links
[Upstream repository](https://github.com/holoviz/geoviews)
[Upstream changelog/diff](https://github.com/holoviz/geoviews/compare/v1.13.1...v1.14.0)